### PR TITLE
Reduce the build time of platform-pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,19 +21,22 @@ jobs:
           mkdir $GOPATH/download
           cd $GOPATH/download
     - run:
-        name: Clone token-contracts, platform-contracts, snet-cli & snet-daemon
+        name: Clone token-contracts, platform-contracts, snet-cli, snet-sdk-js & snet-daemon
         command: |
           cd $SINGNET_REPOS
           git clone https://github.com/singnet/token-contracts.git
           git clone https://github.com/singnet/platform-contracts.git
           git clone https://github.com/singnet/snet-cli.git
           git clone https://github.com/singnet/snet-daemon.git
+          git clone https://github.com/singnet/snet-sdk-js.git
     - restore_cache:
         key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
     - restore_cache:
         key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
     - restore_cache:
         key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.toml" }}
+    - restore_cache:
+        key: dependency-cache-{{ checksum "../snet-sdk-js/package.json" }}
     - run:
         name: Build token-contracts
         command: |
@@ -62,6 +65,11 @@ jobs:
           popd
           ./packages/snet_cli/scripts/blockchain install
           pip3 install -e ./packages/snet_cli
+    - run:
+        name: Build snet-sdk-js
+        command: |
+          cd $SINGNET_REPOS/snet-sdk-js
+          npm install
     - run:
         name: Build snet-daemon
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,18 @@ jobs:
           mkdir $GOPATH/download
           cd $GOPATH/download
     - run:
-        name: Clone token-contracts, platform-contracts
+        name: Clone token-contracts, platform-contracts, snet-cli & snet-daemon
         command: |
           cd $SINGNET_REPOS
           git clone https://github.com/singnet/token-contracts.git
           git clone https://github.com/singnet/platform-contracts.git
+          git clone https://github.com/singnet/snet-cli.git
+          git clone https://github.com/singnet/snet-daemon.git
     - restore_cache:
-        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
-    - restore_cache:
-        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
+        keys:
+          - dependency-cache-{{ checksum "../token-contracts/package.json" }}
+          - dependency-cache-{{ checksum "../platform-contracts/package.json" }}
+          - dependency-cache-{{ checksum "../snet-daemon/Gopkg*" }}
     - run:
         name: Build token-contracts
         command: |
@@ -47,20 +50,10 @@ jobs:
           npm install
           npm run-script compile
           npm run-script package-npm
-    - save_cache:
-        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
-        paths:
-          - ../token-contracts/node_modules
-    - save_cache:
-        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
-        paths:
-          - ../platform-contracts/node_modules
     - run:
         name: Build snet-cli
         command: |
-          cd $SINGNET_REPOS
-          git clone https://github.com/singnet/snet-cli.git
-          cd snet-cli
+          cd $SINGNET_REPOS/snet-cli
           # install token-contracts and platform-contracts from local dir
           pushd blockchain/
           npm install $SINGNET_REPOS/token-contracts/build/npm-module
@@ -72,9 +65,7 @@ jobs:
         name: Build snet-daemon
         command: |
           export PATH=$PATH:$GOPATH/bin
-          cd $SINGNET_REPOS
-          git clone https://github.com/singnet/snet-daemon.git
-          cd snet-daemon
+          cd $SINGNET_REPOS/snet-daemon
           # install token-contracts and platform-contracts from local dir
           pushd resources/blockchain
           npm install $SINGNET_REPOS/token-contracts/build/npm-module
@@ -99,3 +90,15 @@ jobs:
           go get github.com/DATA-DOG/godog/cmd/godog
           go get github.com/ethereum/go-ethereum/common
           godog
+    - save_cache:
+        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+        paths:
+          - ../token-contracts/node_modules
+    - save_cache:
+        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
+        paths:
+          - ../platform-contracts/node_modules
+    - save_cache:
+        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg*" }}
+        paths:
+          - ../../../../pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,11 @@ jobs:
           git clone https://github.com/singnet/snet-cli.git
           git clone https://github.com/singnet/snet-daemon.git
     - restore_cache:
-        keys:
-          - dependency-cache-{{ checksum "../token-contracts/package.json" }}
-          - dependency-cache-{{ checksum "../platform-contracts/package.json" }}
-          - dependency-cache-{{ checksum "../snet-daemon/Gopkg*" }}
+        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+    - restore_cache:
+        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
+    - restore_cache:
+        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.lock" }}
     - run:
         name: Build token-contracts
         command: |
@@ -99,6 +100,6 @@ jobs:
         paths:
           - ../platform-contracts/node_modules
     - save_cache:
-        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg*" }}
+        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.lock" }}
         paths:
           - ../../../../pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     - restore_cache:
         key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
     - restore_cache:
-        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.lock" }}
+        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.toml" }}
     - run:
         name: Build token-contracts
         command: |
@@ -100,6 +100,6 @@ jobs:
         paths:
           - ../platform-contracts/node_modules
     - save_cache:
-        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.lock" }}
+        key: dependency-cache-{{ checksum "../snet-daemon/Gopkg.toml" }}
         paths:
           - ../../../../pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: ubuntu:latest
+    - image: singularitynet/platform-pipeline
     working_directory: /root/singnet/src/github.com/singnet/platform-pipeline
     environment:
       GOPATH: /root/singnet
@@ -20,31 +20,24 @@ jobs:
           export PATH=$PATH:$GOPATH/bin
           mkdir $GOPATH/download
           cd $GOPATH/download
-          apt-get update
-          apt-get -y install sudo wget git
-          # Install NodeJS toolset
-          sudo apt-get -y install nodejs npm
-          # install Go tools
-          sudo apt-get -y install golang go-dep golint protobuf-compiler
-          # install IPFS
-          wget https://dist.ipfs.io/go-ipfs/v0.4.17/go-ipfs_v0.4.17_linux-amd64.tar.gz
-          tar xvfz go-ipfs_*.tar.gz
-          cp ./go-ipfs/ipfs /usr/local/bin
-          # Installl Python
-          sudo apt-get -y install python3 python3-pip
-          python3 -m pip install --upgrade pip
-          pip3 install --upgrade setuptools
-          # Install other
-          sudo apt-get -y install libudev-dev libusb-1.0-0-dev
     - run:
-        name: Build token-contracts
+        name: Clone token-contracts, platform-contracts
         command: |
           cd $SINGNET_REPOS
           git clone https://github.com/singnet/token-contracts.git
-          cd token-contracts
+    - restore_cache:
+        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+    - run:
+        name: Build token-contracts
+        command: |
+          cd $SINGNET_REPOS/token-contracts
           npm install
           npm run-script compile
           npm run-script package-npm
+    - save_cache:
+        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+        paths:
+          - $SINGNET_REPOS/token-contracts/node_modules
     - run:
         name: Build platform-contracts
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,11 @@ jobs:
         command: |
           cd $SINGNET_REPOS
           git clone https://github.com/singnet/token-contracts.git
+          git clone https://github.com/singnet/platform-contracts.git
     - restore_cache:
         key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+    - restore_cache:
+        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
     - run:
         name: Build token-contracts
         command: |
@@ -34,22 +37,24 @@ jobs:
           npm install
           npm run-script compile
           npm run-script package-npm
-    - save_cache:
-        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
-        paths:
-          - $SINGNET_REPOS/token-contracts/node_modules
     - run:
         name: Build platform-contracts
         command: |
-          cd $SINGNET_REPOS
-          git clone https://github.com/singnet/platform-contracts.git
-          cd platform-contracts
+          cd $SINGNET_REPOS/platform-contracts
           npm install ganache-cli@6.3.0
           # install token-contracts from local dir
           npm install $SINGNET_REPOS/token-contracts/build/npm-module
           npm install
           npm run-script compile
           npm run-script package-npm
+    - save_cache:
+        key: dependency-cache-{{ checksum "../token-contracts/package.json" }}
+        paths:
+          - ../token-contracts/node_modules
+    - save_cache:
+        key: dependency-cache-{{ checksum "../platform-contracts/package.json" }}
+        paths:
+          - ../platform-contracts/node_modules
     - run:
         name: Build snet-cli
         command: |


### PR DESCRIPTION
Reduce the build time of platform-pipeline by

- Using the prebuilt docker image with all required tools
- Caching the dependencies based on the checksum of the requirement file.